### PR TITLE
Don't listen to time picker "change" event

### DIFF
--- a/src/js/modules/Edit/defaults/editors/time.js
+++ b/src/js/modules/Edit/defaults/editors/time.js
@@ -71,8 +71,7 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
+	//submit new value on blur
 	input.addEventListener("blur", onChange);
 	
 	//submit new value on enter


### PR DESCRIPTION
This event fires with nearly every key press when typing a new time, calling onChange(e) before the time can be typed fully.