### PR TITLE
Fix date/time editors

### DIFF
--- a/src/js/modules/Edit/defaults/editors/date.js
+++ b/src/js/modules/Edit/defaults/editors/date.js
@@ -83,9 +83,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){

--- a/src/js/modules/Edit/defaults/editors/datetime.js
+++ b/src/js/modules/Edit/defaults/editors/datetime.js
@@ -70,9 +70,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){

--- a/src/js/modules/Edit/defaults/editors/time.js
+++ b/src/js/modules/Edit/defaults/editors/time.js
@@ -71,9 +71,12 @@ export default function(cell, onRendered, success, cancel, editorParams){
 		}
 	}
 	
-	//submit new value on blur or change
-	input.addEventListener("change", onChange);
-	input.addEventListener("blur", onChange);
+	//submit new value on blur
+	input.addEventListener("blur", function(e) {
+		if (e.relatedTarget || e.rangeParent || e.explicitOriginalTarget !== input) {
+			onChange(e); // only on a "true" blur; not when focusing browser's date/time picker
+		}
+	});
 	
 	//submit new value on enter
 	input.addEventListener("keydown", function(e){


### PR DESCRIPTION
The "change" event fires prematurely with keyboard entry, so it's better to use the "blur" event to process the final value. However, FireFox fires a "blur" event when the user opens the built-in date/time picker, so we have to add some logic to ignore that case.